### PR TITLE
fix: idempotent imports, stable resume storage, and pause/resume robustness

### DIFF
--- a/src-tauri/src/commands/download.rs
+++ b/src-tauri/src/commands/download.rs
@@ -74,18 +74,18 @@ pub async fn add_download_tasks(
     let mut manager = state.download_manager.write().await;
 
     let mut created_tasks = Vec::new();
-    let mut skipped_duplicates = Vec::new();
+    let mut reused_tasks = Vec::new();
     let mut failed_tasks = Vec::new();
 
     for task in tasks {
         // 尝试添加任务到管理器，处理重复项
         match manager.add_video_task(task.clone()).await {
-            Ok(stored) => {
-                created_tasks.push(stored);
-            }
-            Err(AppError::Config(msg)) if msg.contains("Duplicate task") => {
-                skipped_duplicates.push(task.title.clone());
-                tracing::warn!("Skipped duplicate task: {} ({})", task.title, task.url);
+            Ok(result) => {
+                if result.created {
+                    created_tasks.push(result.task);
+                } else {
+                    reused_tasks.push(result.task);
+                }
             }
             Err(e) => {
                 failed_tasks.push(format!("{}: {}", task.title, e));
@@ -95,11 +95,10 @@ pub async fn add_download_tasks(
     }
 
     // 创建详细的日志信息
-    if !skipped_duplicates.is_empty() {
+    if !reused_tasks.is_empty() {
         tracing::info!(
-            "Skipped {} duplicate tasks: {:?}",
-            skipped_duplicates.len(),
-            skipped_duplicates
+            "Reused {} existing tasks",
+            reused_tasks.len()
         );
     }
     if !failed_tasks.is_empty() {
@@ -111,13 +110,14 @@ pub async fn add_download_tasks(
     }
 
     tracing::info!(
-        "Successfully created {} download tasks (skipped {} duplicates, {} failed)",
+        "Successfully created {} download tasks (reused {}, {} failed)",
         created_tasks.len(),
-        skipped_duplicates.len(),
+        reused_tasks.len(),
         failed_tasks.len()
     );
 
     // 即使有一些失败或重复，也返回成功创建的任务
+    created_tasks.extend(reused_tasks);
     Ok(created_tasks)
 }
 

--- a/src-tauri/src/core/downloader.rs
+++ b/src-tauri/src/core/downloader.rs
@@ -84,11 +84,13 @@ use tokio::sync::{mpsc, Mutex, RwLock, Semaphore};
 use tokio::time::sleep;
 use uuid::Uuid;
 
+use directories::ProjectDirs;
 use crate::core::m3u8_downloader::{M3U8Downloader, M3U8DownloaderConfig};
 use crate::core::models::*;
 use crate::core::resume_downloader::{
-    ResumeDownloader, ResumeDownloaderConfig, ResumeProgressCallback,
+    ResumeDownloader, ResumeDownloaderConfig, ResumeInfo, ResumeProgressCallback,
 };
+use sha2::{Digest, Sha256};
 
 /// HTTP下载器配置
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -224,6 +226,8 @@ impl HttpDownloader {
             .user_agent(&config.user_agent)
             .build()?;
 
+        let resume_dir = Self::resolve_resume_dir();
+
         let max_concurrent = Arc::new(AtomicUsize::new(config.max_concurrent));
         let semaphore = Arc::new(Semaphore::new(config.max_concurrent));
 
@@ -234,7 +238,7 @@ impl HttpDownloader {
             large_file_threshold: 50 * 1024 * 1024, // 50MB 阈值
             max_retries: config.retry_attempts,
             retry_delay: Duration::from_secs(2),
-            resume_info_dir: std::env::temp_dir().join("video_downloader_resume"),
+            resume_info_dir: resume_dir,
             server_cache_ttl: Duration::from_secs(24 * 60 * 60), // 24小时
         };
 
@@ -274,6 +278,14 @@ impl HttpDownloader {
         self.bandwidth_controller.clone()
     }
 
+    pub async fn load_resume_info(&self, resume_key: &str) -> Option<ResumeInfo> {
+        self.resume_downloader
+            .load_resume_info(resume_key)
+            .await
+            .ok()
+            .flatten()
+    }
+
     /// 设置进度回调
     pub fn set_progress_callback(&mut self, tx: mpsc::UnboundedSender<(String, DownloadStats)>) {
         self.progress_tx = Some(tx.clone());
@@ -309,6 +321,19 @@ impl HttpDownloader {
                 );
             }
         }
+    }
+
+    fn build_resume_key(&self, task: &DownloadTask) -> String {
+        let identity = format!("{}|{}|{}", task.url, task.output_path, task.filename);
+        let mut hasher = Sha256::new();
+        hasher.update(identity.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
+    fn resolve_resume_dir() -> std::path::PathBuf {
+        ProjectDirs::from("com", "video-downloader", "VideoDownloaderPro")
+            .map(|dirs| dirs.data_local_dir().join("resume"))
+            .unwrap_or_else(|| std::env::temp_dir().join("video_downloader_resume"))
     }
 
     /// 开始下载单个文件
@@ -540,9 +565,10 @@ impl HttpDownloader {
 
         let task_id = task.id.clone();
         let task_url = task.url.clone();
+        let resume_key = self.build_resume_key(task);
 
         let mut resume_future = Box::pin(self.resume_downloader.download_with_resume(
-            &task_id,
+            &resume_key,
             &task_url,
             Path::new(&output_path_str),
             task.stats.total_bytes,

--- a/src-tauri/src/core/resume_downloader.rs
+++ b/src-tauri/src/core/resume_downloader.rs
@@ -785,7 +785,7 @@ impl ResumeDownloader {
     }
 
     /// 加载断点续传信息
-    async fn load_resume_info(&self, task_id: &str) -> Result<Option<ResumeInfo>> {
+    pub async fn load_resume_info(&self, task_id: &str) -> Result<Option<ResumeInfo>> {
         // 先检查内存缓存
         {
             let cache = self.resume_info_cache.read().await;


### PR DESCRIPTION
### Motivation
- Ensure resume metadata is persisted in a stable, platform-appropriate location so resume state survives restarts and re-imports.
- Make task imports and additions idempotent so re-importing the same items reuses existing tasks and avoids duplicate rows or lost resume state.
- Harden pause/resume behavior to be idempotent and avoid automatic immediate restarts while keeping task status and file/resume hydration consistent.

### Description
- Use a stable app data directory for resume metadata by resolving an application data path with `directories::ProjectDirs` and falling back to `std::env::temp_dir()`; wire this into `ResumeDownloader` via `HttpDownloader::new` (files: `src-tauri/src/core/downloader.rs`, `src-tauri/src/core/resume_downloader.rs`).
- Introduce SHA-256 based resume keys and identity keys derived from `url|output_path|filename` to consistently locate resume metadata across runs; add `build_resume_key` and `build_identity_key` helpers used by the downloader and manager (files: `src-tauri/src/core/downloader.rs`, `src-tauri/src/core/manager.rs`).
- Make `ResumeDownloader::load_resume_info` public and expose `HttpDownloader::load_resume_info` for manager hydration logic so resume metadata contributes to `file_size`/`downloaded_size`/`status`/`progress` when importing or refreshing tasks (files: `src-tauri/src/core/resume_downloader.rs`, `src-tauri/src/core/downloader.rs`, `src-tauri/src/core/manager.rs`).
- Change task-add APIs to return an `AddVideoTaskResult { task, created }` so callers can distinguish newly created tasks from reused existing tasks and keep behavior idempotent; update command handlers to collect reused tasks and merge them into results instead of treating them as errors (files: `src-tauri/src/core/manager.rs`, `src-tauri/src/commands/download.rs`, `src-tauri/src/commands/import.rs`).
- Improve `pause_download` to be idempotent and safe: gracefully handle missing/finished tasks, abort/remove active handles, call into the downloader to cancel underlying activity, only update and emit `TaskPaused` when appropriate, and prevent immediate auto-restart (file: `src-tauri/src/core/manager.rs`).
- Hydrate and refresh file/resume state before resume/start so tasks accurately reflect on-disk progress and transition to `Paused` when appropriate; add `load_resume_total_size` integration to hydrate logic (file: `src-tauri/src/core/manager.rs`).
- Frontend store merging: update `src/stores/downloadStore.ts` to merge backend tasks into the existing task list by `id` (replace blind concatenation) and update the progress listener to freeze the auto-start queue and remove paused tasks from `pendingStartQueue` when a `paused` status arrives (file: `src/stores/downloadStore.ts`).

### Testing
- No automated test suites were executed as part of this change; automated tests were not run locally or in CI for this patch.
- Recommended verification commands to run in CI or locally are: `pnpm test`, `pnpm test:integration`, `pnpm dev` (manual UI checks for import/pause/resume/queue behavior), and `cd src-tauri && cargo test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973723056348325b0320d393006a534)