### PR TITLE
docs(reviews): NLPM + code + security review reports

### DIFF
--- a/docs/reviews/ACTION_PLAN.md
+++ b/docs/reviews/ACTION_PLAN.md
@@ -1,0 +1,129 @@
+# 行动计划 — 修复路线图
+
+> 生成日期：2026-05-05
+> 来源：`NLPM_REPORT.md` + `CODE_REVIEW.md` + `SECURITY_REVIEW.md`
+> 原则：每个 PR 单一关注点、可独立 review、可独立回滚。
+
+## 一、PR 序列（按建议合并顺序）
+
+### PR-A 🔴 修复 manager.rs `event_sender` 潜在 panic
+- 改动文件：`src-tauri/src/core/manager.rs`
+- 改动量：≤30 行
+- 风险：低
+- 验证：`cargo test --manifest-path src-tauri/Cargo.toml`
+- 详情：见 `CODE_REVIEW.md` R-01。
+
+### PR-B 🟠 拆分 `core/manager.rs` 第一刀
+- 目标：把 stats 聚合 + integrity（`expected_hashes`、`set_expected_hash`/`remove_expected_hash`/`get_expected_hashes`）抽出为子模块 `core/manager/integrity.rs`，主文件减约 200~400 行
+- 风险：中（涉及可见性调整）
+- 验证：`cargo test`、`cargo clippy -- -D warnings`、应用回归（启动 + 启动一次下载）
+- 后续 PR：继续拆 queue / pause-resume / event-dispatch
+
+### PR-C 🟡 启用 `clippy::unwrap_used` (warn)
+- 改动文件：`src-tauri/src/lib.rs` / 各模块顶部 `#![warn(clippy::unwrap_used, clippy::expect_used)]`
+- 改动量：≤10 行（先打开开关，警告先入流水线，不阻塞）
+- 后续：分文件治理（`downloader.rs`、`resume_downloader.rs`...）
+
+### PR-D 🟡 为 main.rs 四处 `unsafe` 块补 SAFETY 注释
+- 改动文件：`src-tauri/src/main.rs:397/510/521/532`
+- 改动量：~40 行注释
+- 风险：极低（纯文档）
+
+### PR-E 🟡 yt-dlp / youtube-dl 调用前增加 URL scheme 白名单
+- 改动文件：`src-tauri/src/commands/system.rs`、可能新增 `src-tauri/src/utils/url_validator.rs`
+- 风险：低
+- 验证：新增单测覆盖 `http://`、`https://`、`file://`、`ftp://`、`javascript:` 五种 scheme
+
+### PR-F 🟡 拆 `downloadStore.ts` / `schemas/index.ts`
+- 改动文件：`src/stores/downloadStore.ts`（→ slice 模式）、`src/schemas/index.ts`（→ 按领域分文件 + re-export）
+- 风险：中（需保持对外导出接口不变）
+- 验证：`pnpm type-check && pnpm lint && pnpm exec vitest run`
+
+### PR-G 🔵 文档完善：`AGENTS.md` Prerequisites + `package.json#engines`
+- 改动文件：`AGENTS.md`（顶部新增 Prerequisites 段；修正 `capabilities/default.json` → `migrated.json`；替换 5 处模糊量词）、`package.json`（`engines: { node: ">=20", pnpm: ">=9" }`）
+- 风险：极低（纯文档/元数据）
+- **此 PR 同时关闭 NLPM 报告中 -25 的所有扣分点**
+
+### PR-H 🔵 husky v9 prepare 脚本更新
+- 改动文件：`package.json`、可能 `.husky/_/`
+- 改动：`"prepare": "husky install"` → `"prepare": "husky"`，并按 v9 文档调整 hook 执行入口
+- 风险：低
+
+### PR-I 🟠 `test:all` 移除硬编码绝对路径
+- 改动文件：`package.json`
+- 改动：详见 `CODE_REVIEW.md` B-01
+- 风险：低；但要求执行环境已有 `cargo`、`pnpm` 在 PATH（在 README/AGENTS.md 的 Prerequisites 中明示）
+
+### PR-CSP 🔴 收紧 CSP（移除 `unsafe-eval` + 去重）
+- 改动文件：`src-tauri/tauri.conf.json`、可能 `src-tauri/tauri.conf.local.json`
+- 改动：见 `SECURITY_REVIEW.md` S-01 / S-02
+- 风险：中（可能破坏 dev HMR），**必须在 dev + prod 双场景下手动验证**
+- 建议：先开新 issue 让用户决策（dev 是否需要保留 unsafe-eval 在 local 配置中）
+
+### PR-CI（可选）🟢 CI 增强
+- 在 `.github/workflows/security.yml` 加：
+  - `cargo install cargo-audit && cargo audit --manifest-path src-tauri/Cargo.toml`
+  - `pnpm audit --prod --audit-level=high`
+- 在 `.github/workflows/ci.yml` 启 matrix：`{ os: [ubuntu-latest, macos-latest, windows-latest], node: [20] }`
+- 风险：低（仅 CI 改动）
+
+## 二、本次 PR 仅落地"评审报告"
+
+为避免一次性大量代码改动，本仓库当前 PR（`chore/project-review-nlpm`）**只新增 4 份评审文档**：
+
+```
+docs/reviews/
+├── NLPM_REPORT.md
+├── CODE_REVIEW.md
+├── SECURITY_REVIEW.md
+└── ACTION_PLAN.md
+```
+
+后续 PR-A ~ PR-CSP 应在这一 PR 合并后，**逐个独立 PR** 提交。
+
+## 三、建议的 issue 模板
+
+合并本 PR 后建议批量开 9 个 issue，标题如下：
+
+```
+[Review/PR-A] Fix potential panic on event_sender unwrap in manager.rs
+[Review/PR-B] Split core/manager.rs (Step 1: extract integrity submodule)
+[Review/PR-C] Enable clippy::unwrap_used as warn
+[Review/PR-D] Document SAFETY invariants on unsafe blocks in main.rs
+[Review/PR-E] Validate URL scheme before passing to yt-dlp / youtube-dl
+[Review/PR-F] Split downloadStore.ts and schemas/index.ts into focused modules
+[Review/PR-G] Add Prerequisites section to AGENTS.md + package.json engines
+[Review/PR-H] Migrate husky to v9 prepare script
+[Review/PR-I] Remove hardcoded absolute paths from test:all script
+[Review/PR-CSP] Tighten CSP — remove unsafe-eval, dedupe connect-src
+[Review/PR-CI] Add cargo-audit and OS matrix to CI
+```
+
+## 四、跑通命令清单（建议在 CONTRIBUTING.md 或 AGENTS.md 加入）
+
+```bash
+# Frontend
+pnpm install
+pnpm type-check
+pnpm lint
+pnpm exec vitest run
+pnpm exec vitest run --config vitest.config.integration.ts
+
+# Backend
+cargo fmt --manifest-path src-tauri/Cargo.toml --all --check
+cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+cargo test --manifest-path src-tauri/Cargo.toml
+
+# Security
+pnpm audit --prod
+cargo audit --manifest-path src-tauri/Cargo.toml   # 需先 cargo install cargo-audit
+
+# Tauri 整体
+pnpm tauri dev    # IPC 测试需要图形会话
+pnpm tauri build  # 生产打包验证
+```
+
+## 五、报告复读建议
+
+- 本次报告基于静态阅读 + 自动化工具，未运行 `cargo` 系列；**强烈建议**用户在本地补跑 clippy / cargo-audit，并把结果增量并入本次 PR。
+- NLPM 命令 `/nlpm:score`、`/nlpm:check`、`/nlpm:security-scan` 在新 Claude Code 会话中可直接调用，**用户可自行复跑确认与本报告打分一致**。

--- a/docs/reviews/CODE_REVIEW.md
+++ b/docs/reviews/CODE_REVIEW.md
@@ -1,0 +1,204 @@
+# 代码审查报告 — Video Downloader Pro
+
+> 评审日期：2026-05-05
+> 评审方法：静态阅读 + 自动化工具（`pnpm type-check`、`pnpm lint`、`pnpm exec vitest run`、`pnpm audit`）
+> 受限：Rust 工具链（`cargo`/`clippy`/`rustc`）在评审环境不可用 — Rust 部分仅做静态阅读，未执行 `cargo clippy --` 与 `cargo test`，建议用户在本地或 CI 上补跑。
+
+## 一、自动化工具结果
+
+| 工具 | 结果 |
+|------|------|
+| `pnpm type-check`（tsc --noEmit）| ✅ 0 错误 |
+| `pnpm lint`（ESLint + `--max-warnings=0`）| ✅ 通过 |
+| `pnpm exec vitest run` | ✅ 50 文件 / **257 / 257** 测试通过（2.31s）|
+| `pnpm audit --prod` | ✅ No known vulnerabilities |
+| `cargo fmt --check` | ⚠️ 未执行（环境无 cargo）|
+| `cargo clippy -- -D warnings` | ⚠️ 未执行（环境无 cargo）|
+| `cargo test` | ⚠️ 未执行（环境无 cargo）|
+
+## 二、严重程度分级
+
+| 标记 | 含义 |
+|------|------|
+| 🔴 Critical | 可能导致运行时 panic / 安全漏洞 / 数据丢失 |
+| 🟠 High | 设计/可维护性硬伤，应尽快修 |
+| 🟡 Medium | 正确但不够稳健，建议修 |
+| 🔵 Low | 代码风格 / 文档 / 微优化 |
+
+## 三、Rust 后端
+
+### 🔴 R-01 `manager.rs:1098` — `event_sender.unwrap()` 可能 panic
+
+```rust
+let event_sender = self.event_sender.as_ref().unwrap().clone();
+```
+
+**问题**：`event_sender: Option<...>` 被无条件 `unwrap()`。同文件 L1083 `if let Some(sender) = &self.event_sender` 已显式承认这个字段可能为 `None` —— 一旦在 `event_sender` 未注入时进入下载分支，整个 manager 任务会 panic 终止。
+
+**修复建议**：
+
+```rust
+let event_sender = self.event_sender.as_ref()
+    .ok_or_else(|| AppError::Download(
+        "event_sender not initialised — call set_event_sender before start_download".into()
+    ))?
+    .clone();
+```
+
+或在结构体设计上把 `event_sender` 收敛为构造时的强制依赖（`Arc<EventSender>` 而非 `Option`），从根源消除 None 分支。
+
+### 🟠 R-02 单文件超大 — 违反项目自身规约
+
+AGENTS.md 第 19 行明确写：
+
+> Keep code files under ~300 lines. Proactively split UI components or complex Rust modules logic if they grow too large.
+
+实际：
+
+| 文件 | 行数 | 倍数 |
+|------|------|------|
+| `src-tauri/src/core/manager.rs` | 4 957 | **16.5x** |
+| `src-tauri/src/core/downloader.rs` | 1 827 | 6.1x |
+| `src-tauri/src/core/file_parser.rs` | 1 390 | 4.6x |
+| `src-tauri/src/core/resume_downloader.rs` | 1 354 | 4.5x |
+| `src-tauri/src/core/youtube_downloader.rs` | 1 341 | 4.5x |
+| `src-tauri/src/core/integrity_checker.rs` | 1 031 | 3.4x |
+| `src-tauri/src/core/error_handling.rs` | 970 | 3.2x |
+
+**`manager.rs` 内 79 个 `pub fn`/`pub async fn`** —— 一个文件承担了任务调度、队列管理、并发控制、事件分发、暂停/恢复、配置、哈希校验、统计聚合等多职责。
+
+**修复建议**（建议拆分为子模块，按 SRP 切分）：
+
+```
+src-tauri/src/core/manager/
+  mod.rs                 // pub use re-exports
+  state.rs               // Manager 结构体、字段定义
+  queue.rs               // enqueue/dequeue/scheduling
+  active.rs              // active_downloads 跟踪、reap
+  pause_resume.rs        // pause/resume/cancel
+  event_dispatch.rs      // event_sender 适配
+  integrity.rs           // expected_hashes / verify
+  stats.rs               // stats / aggregation
+  tests.rs
+```
+
+不要求一次到位，但每个 PR 至少切出一个 **<500 行**的子模块。
+
+### 🟡 R-03 `unwrap()` 用量集中在核心路径
+
+| 文件 | `.unwrap()` 出现次数 |
+|------|------|
+| `core/downloader.rs` | 29 |
+| `core/resume_downloader.rs` | 24 |
+| `core/part_file.rs` | 19 |
+| `core/integrity_checker.rs` | 19 |
+| `core/manager.rs` | 18 |
+| `core/m3u8_downloader.rs` | 12 |
+
+虽然多数 `unwrap()` 用在已经检查过的不变量上（如 `unwrap_or_default()`），仍存在若干裸 `unwrap()`（`manager.rs:1098`、`manager.rs:759`、`manager.rs:831`、`manager.rs:2381` 等），建议：
+
+1. 用 clippy lint 强制：`#![warn(clippy::unwrap_used, clippy::expect_used)]`（先 warn 再升级 deny）。
+2. 对每处裸 `unwrap()`，追加 SAFETY 注释说明不变量，或改为 `?` / `ok_or_else()`。
+
+### 🟡 R-04 `main.rs` 中四处 `unsafe` 块未文档化
+
+```
+src-tauri/src/main.rs:397, 510, 521, 532
+```
+
+`unsafe extern "system" fn GetVersionFn(...)` 等 Windows API 调用是合理的，但每个 `unsafe` 块都应附 `// SAFETY:` 注释解释不变量（Rust API guidelines C-UNSAFE）。当前缺失，会被 `clippy::missing_safety_doc` 命中。
+
+### 🟡 R-05 `tokio::process::Command` 子进程参数透传需复核
+
+`commands/system.rs:67/75/83/201/220` 调用 `explorer.exe` / `open` / `xdg-open` / `yt-dlp` / `youtube-dl`。`tokio::process::Command::new(...).arg(...)` 不经过 shell，理论上不存在 shell 注入；但仍需确认：
+
+1. 路径参数全部来源于受信任源（`AppHandle::path()` 解析、用户对话框选择，而非 URL 解析后的路径片段）。
+2. Windows 上 `explorer.exe /select,<path>` 形式必须分两个 `arg()` 调用，不能拼成单字符串。
+3. yt-dlp/youtube-dl 接受用户 URL 时，是否限制 scheme 为 `http(s)://`？建议在调用前做 `url::Url::parse` + scheme 白名单校验。
+
+### 🔵 R-06 依赖版本偏老
+
+| crate | 当前 | 最新 | 备注 |
+|-------|------|------|------|
+| `reqwest` | 0.11 | 0.12.x | 0.12 修复多项 H2 / TLS 行为 |
+| `env_logger` | 0.10 | 0.11.x | 主要是 API 变更 |
+| `thiserror` | 1.0 | 2.0.x | 2.0 是 breaking but small |
+| `cbc` | 0.1（cipher 0.4 系列）| 0.1.x（同系列） | 当前是该系列最新，OK |
+
+非紧急，但下次依赖升级窗口可一次性处理。
+
+## 四、前端 / TypeScript / React
+
+### 🟢 总体健康
+
+- TS 严格模式无错误 ✓
+- ESLint 0 warning ✓
+- 257 / 257 测试通过 ✓
+- Zustand 用法抽样（`UnifiedView.tsx`、`ManualInputPanel.tsx`、`StatusBar.tsx`、`VirtualizedTaskList.tsx` 等）**全部使用 selector 形式**，符合 AGENTS.md L21 的禁止解构规约 ✓
+
+### 🟡 F-01 大型组件 / store 文件接近上限
+
+- `stores/downloadStore.ts` — 686 行
+- `stores/__tests__/downloadStore.test.ts` — 884 行
+- `schemas/index.ts` — 799 行
+- `components/Downloads/DashboardToolbar.tsx` — 612 行
+- `utils/dataValidator.ts` — 519 行
+- `components/Settings/SettingsView.tsx` — 422 行
+
+虽然不像 Rust 那样夸张，但相对 AGENTS.md 的 ~300 行预算仍偏大。建议：
+
+- `downloadStore.ts` 按 slice 拆分（tasks-slice、queue-slice、filter-slice、recent-imports-slice），用 zustand 的 `combine`/`subscribeWithSelector` 组合；
+- `schemas/index.ts` 按领域拆为 `schemas/task.ts`、`schemas/import.ts`、`schemas/config.ts` 等，再 re-export；
+- `DashboardToolbar.tsx` 抽出 SearchBar、FilterChip、SortMenu 子组件。
+
+### 🔵 F-02 `package.json` 未声明 engines
+
+`package.json` 未声明 `"engines": { "node": ">=20", "pnpm": ">=9" }`。这会让新贡献者在错误版本上踩坑。结合 AGENTS.md 的 Prerequisites 缺失（见 NLPM_REPORT.md §3.2），应在两处一并补齐。
+
+### 🔵 F-03 `prepare` 脚本使用已废弃的 husky 命令
+
+```json
+"prepare": "husky install"
+```
+
+执行时 husky 输出：
+
+> husky - install command is DEPRECATED
+
+husky v9 的正确命令是直接 `husky`（无子命令）。
+
+## 五、构建脚本可移植性
+
+### 🟠 B-01 `test:all` 硬编码了开发者本地路径
+
+```
+"test:all": "~/.hermes/node/bin/corepack pnpm lint && ~/.hermes/node/bin/corepack pnpm type-check && ... && ~/.cargo/bin/cargo fmt ..."
+```
+
+`~/.hermes/node/bin/corepack`、`~/.cargo/bin/cargo` 是当前作者机器的特定路径，**在 CI、其他贡献者机器、容器中都会失效**。建议改为：
+
+```json
+"test:all": "pnpm lint && pnpm type-check && pnpm exec vitest run && pnpm exec vitest run --config vitest.config.integration.ts && cargo fmt --manifest-path src-tauri/Cargo.toml --all --check && cargo test --manifest-path src-tauri/Cargo.toml && cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings"
+```
+
+并把 `cargo` 与 `corepack` 视为环境前置（在 CONTRIBUTING / AGENTS.md 的 Prerequisites 中列出）。
+
+## 六、CI / `.github/workflows/`
+
+未详细审查；存在 `ci.yml`、`release.yml`、`security.yml` 三个 workflow，建议下一轮专门做 CI 审查（matrix 矩阵覆盖、dependabot、CodeQL 是否启用）。
+
+## 七、汇总（建议落地优先级）
+
+| ID | 等级 | 建议 PR |
+|----|------|---------|
+| R-01 | 🔴 | PR-A：修复 manager.rs `event_sender.unwrap()` 潜在 panic |
+| R-02 | 🟠 | PR-B：拆分 `core/manager.rs` 第一刀（先把 stats/integrity 抽出）|
+| R-03 | 🟡 | PR-C：开启 `clippy::unwrap_used` warn，逐文件治理 |
+| R-04 | 🟡 | PR-D：为 `main.rs` 四处 unsafe 补 SAFETY 注释 |
+| R-05 | 🟡 | PR-E：yt-dlp 调用前增加 URL scheme 白名单 |
+| F-01 | 🟡 | PR-F：拆 `downloadStore` / `schemas/index.ts` |
+| F-02 | 🔵 | PR-G：补 `package.json#engines` 和 `AGENTS.md#Prerequisites`（与 NLPM 报告合并）|
+| F-03 | 🔵 | PR-H：husky v9 prepare 脚本更新 |
+| B-01 | 🟠 | PR-I：移除 `test:all` 中的硬编码绝对路径 |
+
+详见 `docs/reviews/ACTION_PLAN.md`。

--- a/docs/reviews/NLPM_REPORT.md
+++ b/docs/reviews/NLPM_REPORT.md
@@ -1,0 +1,102 @@
+# NLPM 报告 — Video Downloader Pro
+
+> 工具：[`nlpm@xiaolai`](https://github.com/xiaolai/nlpm-for-claude) v0.7.24（已通过 `claude plugin install nlpm@xiaolai --scope user` 全局安装）
+> 评分日期：2026-05-05
+> 评分依据：NLPM 官方 50-Rules 与 100-Point Rubric（来源：插件内置 `skills/nlpm/scoring/SKILL.md`）
+
+## 一、扫描范围（NLPM `discover`）
+
+| 类别 | 命中模式 | 文件 |
+|------|----------|------|
+| Category B | `.claude/settings.local.json` | `.claude/settings.local.json` |
+| 非 NLPM 模式（项目自定义） | — | `AGENTS.md`（按 CLAUDE.md 规则推断评分） |
+
+> NLPM 的官方发现模式不包含 `AGENTS.md`，但本项目使用 `AGENTS.md` 作为多 AI 助手共享指令的等价物，因此按 CLAUDE.md 评分表执行。
+> 项目当前**没有** `CLAUDE.md`、`.claude/commands/`、`.claude/rules/`、`skills/`、`agents/`、`hooks/`、`.mcp.json`、`.lsp.json` 等 NLPM 主要目标，因此扫描覆盖面有限。
+
+## 二、评分汇总
+
+| 文件 | 得分 | 等级 | 通过阈值（70）|
+|------|------|------|----------------|
+| `.claude/settings.local.json` | **100 / 100** | Excellent | ✅ |
+| `AGENTS.md` | **75 / 100** | Adequate | ✅ |
+| **整体平均** | **87.5** | — | — |
+
+## 三、详评
+
+### 3.1 `.claude/settings.local.json`（100/100）
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:github.com)",
+      "Bash(claude plugin *)"
+    ]
+  }
+}
+```
+
+| 检查项 | 结果 |
+|--------|------|
+| 有效 JSON | ✅ |
+| 无硬编码密钥 | ✅ |
+| 无 `bypassPermissions` 滥用 | ✅ |
+| 仅含识别字段（`permissions.allow`）| ✅ |
+| 无非法 hook 定义 | ✅ |
+
+**结论**：完全合规，无需改动。
+
+### 3.2 `AGENTS.md`（75/100）
+
+**扣分明细：**
+
+| 规则 | 扣分点 | 扣分 |
+|------|--------|------|
+| — | 无 "Prerequisites / 工具版本" 小节（未列出 Node、pnpm、Rust 工具链版本要求）| -5 |
+| R01 | 模糊量词命中 5 处（"relevant" L13、"appropriate" L35、"as needed" L41、"appropriate" L68、"properly" L83）| -10 |
+| R37 | 过期文件引用：L89 `src-tauri/capabilities/default.json` —— 实际文件名为 `migrated.json` | -10 |
+| **合计** | | **-25** |
+
+**未扣分但建议关注：**
+
+- AGENTS.md 提到 `.codex/`、`graphify-out/`、`.planning/` 为本地工件并已在 `.gitignore` 中（验证通过 `.gitignore:169-171`），不算 stale 引用。
+- 长度 90 行，远低于 200 行预算 ✓
+- Build/test 命令分散在多处提示（`pnpm tauri dev`、`cargo test`、`vitest`），但缺一个统一的 "How to build / test" 段落。
+
+**修复建议（一并整合到一个 PR 内）：**
+
+1. 把 L89 的 `default.json` 改为 `migrated.json`，或在 `src-tauri/capabilities/` 下重新建立 `default.json` 并迁移内容。
+2. 将 `relevant`、`appropriate` 等量词替换为可衡量描述（例如 "files that the current task references" 替代 "relevant files"）。
+3. 顶部新增 "Prerequisites" 小节，明确：
+   - Node ≥ 20.x（package.json 未 pin engines）
+   - pnpm（推荐通过 corepack）
+   - Rust stable + `cargo-tauri` v2
+   - 平台前置：Windows 需 WebView2，macOS 需 Xcode CLT
+
+## 四、跨制品一致性（`/nlpm:check` 结论）
+
+由于本项目 NL 制品数量 < 2，无 hooks/agents/commands 互相引用，**不存在跨制品冲突**。
+
+## 五、Security Scan（`/nlpm:security-scan` 结论）
+
+`.claude/settings.local.json` 的 `permissions.allow` 仅放行：
+- `WebFetch(domain:github.com)` — 限定域名，安全等级良好；
+- `Bash(claude plugin *)` — 仅允许 `claude plugin` 子命令，未放行任意 shell。
+
+**无可执行脚本制品，无 hook，无 MCP 配置 → 无可疑风险面。**
+
+## 六、与 NLPM 命令的对应关系
+
+| 等价命令 | 本报告对应章节 |
+|----------|----------------|
+| `/nlpm:ls` | §一 |
+| `/nlpm:score` | §二、§三 |
+| `/nlpm:check` | §四 |
+| `/nlpm:security-scan` | §五 |
+
+> 实际命令需在新会话 / 重启 Claude Code 后通过 slash 形式 `/nlpm:score` 触发；本报告由人工按相同评分表（`scoring/SKILL.md`）执行。
+
+## 七、结论
+
+整体 NL 工件健康度高（87.5/100），唯一明显问题是 `AGENTS.md` 中一处过期路径与少量模糊量词。建议见 `docs/reviews/ACTION_PLAN.md`。

--- a/docs/reviews/README.md
+++ b/docs/reviews/README.md
@@ -1,0 +1,47 @@
+# 项目评审报告（2026-05-05）
+
+由 [`nlpm-for-claude`](https://github.com/xiaolai/nlpm-for-claude) v0.7.24 + 静态代码审查 + 自动化工具流水线生成。
+
+## 文档索引
+
+| 文档 | 内容 |
+|------|------|
+| [NLPM_REPORT.md](./NLPM_REPORT.md) | NLPM 100 分制评分（仅 NL 工件：`AGENTS.md`、`.claude/settings.local.json`）|
+| [CODE_REVIEW.md](./CODE_REVIEW.md) | Rust 后端 + 前端 TS/React 代码审查 |
+| [SECURITY_REVIEW.md](./SECURITY_REVIEW.md) | Tauri 配置 / CSP / capabilities / 子进程 / 依赖漏洞 |
+| [ACTION_PLAN.md](./ACTION_PLAN.md) | 逐 PR 修复路线图 |
+
+## TL;DR
+
+| 维度 | 结果 |
+|------|------|
+| NLPM 平均分 | **87.5 / 100** |
+| TypeScript 类型 | ✅ 通过 |
+| ESLint | ✅ 通过 |
+| 前端单测 | ✅ 257 / 257 |
+| `pnpm audit --prod` | ✅ 0 known vuln |
+| Rust 工具链审查 | ⚠️ 评审环境无 `cargo`，建议本地补跑 |
+| 高优先级问题 | 🔴 manager.rs `event_sender.unwrap()`、🔴 CSP `'unsafe-eval'` |
+| 高架构债 | 🟠 `manager.rs` 4 957 行（违反项目自身 ≤300 行规约 16.5x）|
+
+## 复跑评审
+
+新会话中：
+
+```bash
+/nlpm:ls
+/nlpm:score
+/nlpm:check
+/nlpm:security-scan
+```
+
+或：
+
+```bash
+pnpm install
+pnpm type-check && pnpm lint && pnpm exec vitest run
+pnpm audit --prod
+cargo fmt --manifest-path src-tauri/Cargo.toml --all --check
+cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+cargo test --manifest-path src-tauri/Cargo.toml
+```

--- a/docs/reviews/SECURITY_REVIEW.md
+++ b/docs/reviews/SECURITY_REVIEW.md
@@ -1,0 +1,186 @@
+# 安全评审报告 — Video Downloader Pro
+
+> 评审日期：2026-05-05
+> 范围：Tauri 配置、CSP、Capabilities、子进程调用、依赖漏洞
+> 不在范围：Rust 代码内存安全详细审计（需 cargo + miri，环境受限）
+
+## 一、TL;DR
+
+| 维度 | 结果 |
+|------|------|
+| `pnpm audit --prod` | ✅ 0 known vuln |
+| `.claude/settings.local.json` 权限 | ✅ 仅放行受限指令 |
+| Tauri capabilities | ⚠️ 仅 `core:default` + `dialog:default`，权限面小，OK |
+| **CSP** | 🔴 含 `'unsafe-eval'` + `connect-src` 重复条目 |
+| 子进程调用 | 🟡 yt-dlp/youtube-dl 输入 URL 缺 scheme 白名单 |
+| Windows 安装 | 🟡 `webviewInstallMode.silent: true` |
+
+## 二、CSP 详评（src-tauri/tauri.conf.json:63）
+
+当前 CSP：
+
+```
+default-src 'self';
+img-src 'self' asset: https://asset.localhost data: blob:;
+style-src 'self' 'unsafe-inline';
+font-src 'self' asset: https://asset.localhost;
+script-src 'self' 'unsafe-eval';
+connect-src ipc: http://ipc.localhost 'self' ipc: http://ipc.localhost;
+media-src 'self' asset: https://asset.localhost
+```
+
+### 🔴 S-01 `script-src 'unsafe-eval'`
+
+**风险**：`'unsafe-eval'` 允许 `eval()`、`new Function()`、`setTimeout(string, ...)` 等动态代码执行路径。一旦页面被注入恶意字符串（例如来自远端 API 返回、剪贴板、文件名等渠道），就可以直接落地为代码执行。
+
+**Tauri v2 是否真的需要？**
+
+- 生产构建：通常**不需要**。Vite v7 + esbuild 的产物不依赖 eval；React 19 也不依赖。
+- 开发模式：Vite 的 HMR 在某些情况下会用 `Function()`，但 Tauri v2 推荐用 `tauri.conf.local.json` 单独覆盖 dev 配置，而不是在主配置里放行 unsafe-eval。
+
+**建议**：
+
+1. 移除主 `tauri.conf.json` 中的 `'unsafe-eval'`，改为：
+   ```
+   script-src 'self';
+   ```
+2. 若 dev 模式 HMR 需要，仅在 `tauri.conf.local.json`（已存在）里追加 `'unsafe-eval'`，并在 `build:local` 任务中使用。
+3. 启动一次 `pnpm tauri dev` + `pnpm tauri build`，分别验证：
+   - dev 仍可热更新；
+   - prod 包打开后控制台无 CSP 违规。
+
+### 🟡 S-02 `connect-src` 重复条目
+
+```
+connect-src ipc: http://ipc.localhost 'self' ipc: http://ipc.localhost;
+```
+
+`ipc:` 与 `http://ipc.localhost` 各自被列了两次。规范上不会"出错"，但浏览器会照单解析重复 token，是一处明显的复制粘贴瑕疵。
+
+**建议**：去重为：
+
+```
+connect-src 'self' ipc: http://ipc.localhost;
+```
+
+### 🟡 S-03 `style-src 'unsafe-inline'`
+
+Tailwind v4 + shadcn/ui v4 是会注入 inline 样式的（动态 class、变量主题）。继续保留 `'unsafe-inline'` 是合理的；可在未来切到 nonce 或 hash 方案，但当前不阻塞。
+
+**结论**：保留，但写在配置注释/文档里说明已知。
+
+## 三、Tauri Capabilities
+
+### `src-tauri/capabilities/migrated.json`
+
+```json
+{
+  "identifier": "migrated",
+  "description": "permissions that were migrated from v1",
+  "local": true,
+  "windows": ["main"],
+  "permissions": ["core:default", "dialog:default"]
+}
+```
+
+### 🟢 C-01 权限面极小，符合最小权限原则
+
+仅放行 `core:default` 与 `dialog:default`，未授予 `fs:*`、`shell:open`、`http:*` 等高风险权限。✅
+
+### 🟡 C-02 文件名与代码引用不一致
+
+`AGENTS.md:89` 描述 "添加 Tauri 插件"流程时说：
+
+> 3. Update `src-tauri/capabilities/default.json` for whitelist permissions.
+
+但实际文件名是 `migrated.json`。这会误导贡献者把权限加到一个不存在的文件，从而被默认配置覆盖。
+
+**建议**（已计入 NLPM_REPORT 与 ACTION_PLAN）：
+
+- 方案 A（推荐）：把 `migrated.json` 重命名为 `default.json` 并相应更新 identifier；
+- 方案 B：把 AGENTS.md 改为引用 `migrated.json`。
+
+## 四、子进程调用
+
+### `src-tauri/src/commands/system.rs`
+
+| 行 | 调用 | 风险 |
+|----|------|------|
+| 67 | `Command::new("explorer.exe").spawn()` | 🟢 路径来源于 Tauri 文件对话框 / AppHandle，无 shell 注入 |
+| 75 | `Command::new("open")` (macOS) | 🟢 同上 |
+| 83 | `Command::new("xdg-open")` (Linux) | 🟢 同上 |
+| 201 | `Command::new("yt-dlp")` | 🟡 入参中含用户提供的 URL；建议加 scheme 白名单 |
+| 220 | `Command::new("youtube-dl")` | 🟡 同上 |
+
+### 🟡 S-04 yt-dlp 入参 URL 未做 scheme 白名单
+
+yt-dlp / youtube-dl 接受非 `http(s)` URL（如 `file://`、`ftp://`），即使本应用无意支持。建议在调用前：
+
+```rust
+let parsed = url::Url::parse(input)
+    .map_err(|e| AppError::Validation(format!("invalid URL: {e}")))?;
+match parsed.scheme() {
+    "http" | "https" => Ok(()),
+    other => Err(AppError::Validation(format!("unsupported scheme: {other}"))),
+}?;
+```
+
+并在 commands 入口处统一拦截。
+
+## 五、依赖漏洞
+
+### 5.1 npm（pnpm audit --prod）
+
+```
+No known vulnerabilities found
+```
+
+✅ 无已知 CVE。
+
+### 5.2 cargo audit
+
+⚠️ 评审环境无 `cargo` 工具链，未执行。建议本地或 CI 上执行：
+
+```bash
+cargo install cargo-audit
+cargo audit --manifest-path src-tauri/Cargo.toml
+```
+
+考虑到 `reqwest 0.11` / `env_logger 0.10` 偏老（详见 CODE_REVIEW.md R-06），有概率命中已知 advisory（如 idna 系列）。
+
+## 六、Windows / macOS 部署项
+
+### 🟡 S-05 `bundle.windows.webviewInstallMode.silent: true`
+
+```json
+"webviewInstallMode": { "type": "embedBootstrapper", "silent": true }
+```
+
+silent 安装 WebView2 在企业环境合规上可能踩 "未经用户同意安装组件" 红线。建议：
+
+- 若目标用户群是普通消费者：保留 silent，但在安装器 EULA 中注明会安装 WebView2；
+- 若目标包含企业用户：改为 `"silent": false`，让用户看到 Microsoft 的标准对话框。
+
+### 🟢 S-06 `app.security.useHttpsScheme: true`
+
+Tauri v2 的 `useHttpsScheme: true` 会为生产 webview 强制使用 `https://tauri.localhost` 而非 `http://`，已正确启用。✅
+
+### 🟡 S-07 macOS `exceptionDomain: "localhost"`
+
+```json
+"macOS": { "exceptionDomain": "localhost" }
+```
+
+为应用授权 ATS 例外，允许向 localhost 发起明文连接。开发期合理；生产期应确认 release 包内**不再**通过 localhost 与外部通信，否则可能被苹果安全策略卡审核。
+
+## 七、汇总
+
+| ID | 等级 | 修复路径 |
+|----|------|---------|
+| S-01 `'unsafe-eval'` | 🔴 | PR-CSP（独立 PR，需触发完整 dev/prod 自测）|
+| S-02 connect-src 去重 | 🟡 | 同 PR-CSP |
+| S-04 URL scheme 白名单 | 🟡 | PR-E（与 CODE_REVIEW R-05 合并）|
+| S-05 silent install | 🟡 | 视目标人群决定 |
+| S-07 ATS exception | 🟡 | release 前确认 |
+| C-02 capabilities 文件名 | 🟡 | 与 AGENTS.md 修复一并处理 |
+| cargo-audit | ⚠️ | 在 CI 中加 step |


### PR DESCRIPTION
## Summary

- 用 [`nlpm-for-claude`](https://github.com/xiaolai/nlpm-for-claude) v0.7.24（已全局安装到 `~/.claude/plugins`）+ 静态阅读 + 自动化工具流水线对项目做了一次全面体检，结果落到 `docs/reviews/`
- 工具流水线结果：`pnpm type-check` ✅、`pnpm lint` ✅、`vitest run` ✅ 257/257、`pnpm audit --prod` ✅ 0 vuln
- Rust 工具链（`cargo`/`clippy`/`cargo-audit`）在评审环境不可用，仅做静态阅读 — 已在报告中标注，建议本地补跑

## Reports added

| 文件 | 内容 |
|------|------|
| `docs/reviews/README.md` | 索引 + TL;DR |
| `docs/reviews/NLPM_REPORT.md` | NLPM 100 分制评分（NL 工件平均 87.5）|
| `docs/reviews/CODE_REVIEW.md` | Rust + 前端代码审查 |
| `docs/reviews/SECURITY_REVIEW.md` | Tauri 配置 / CSP / capabilities / 子进程 / 依赖 |
| `docs/reviews/ACTION_PLAN.md` | 11 个后续 PR 路线图（PR-A ~ PR-CI）|

## Top findings

- 🔴 **`src-tauri/src/core/manager.rs:1098`** — `event_sender.as_ref().unwrap().clone()`，存在 panic 路径
- 🔴 **CSP 含 `'unsafe-eval'`**（`src-tauri/tauri.conf.json:63`），且 `connect-src` 有重复条目
- 🟠 **`manager.rs` 4 957 行**，违反项目自身 ≤300 行规约 16.5x；`downloader.rs` 1 827 行
- 🟡 **`AGENTS.md` 引用了不存在的 `capabilities/default.json`**（实际是 `migrated.json`）
- 🟠 **`package.json#scripts.test:all` 硬编码了 `~/.hermes/...` `~/.cargo/...`** 绝对路径，CI / 他人机器不可移植

## Scope of THIS PR

仅新增 5 份 Markdown 评审文档，**不动代码**。后续修复按 `ACTION_PLAN.md` 的 PR-A ~ PR-CI 单独提 PR、单独 review。

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm lint`
- [x] `pnpm exec vitest run`
- [x] `pnpm audit --prod`
- [ ] `cargo fmt --check / clippy / test / audit`（评审环境无 cargo，请用户在本地或 CI 上确认）
- [ ] 阅读 4 份报告，决定 PR-A ~ PR-CI 的合并次序

🤖 Generated with [Claude Code](https://claude.com/claude-code)