### PR TITLE
fix(manager): replace event_sender.unwrap() with explicit error

### DIFF
--- a/src-tauri/src/core/manager.rs
+++ b/src-tauri/src/core/manager.rs
@@ -1095,7 +1095,16 @@ impl DownloadManager {
             .unwrap_or_else(|| task.output_path.clone());
         let initial_downloaded_size = task.downloaded_size;
         let initial_file_size = task.file_size;
-        let event_sender = self.event_sender.as_ref().unwrap().clone();
+        let event_sender = self
+            .event_sender
+            .as_ref()
+            .ok_or_else(|| {
+                AppError::Download(
+                    "event_sender not initialised — call set_event_sender before start_download"
+                        .to_string(),
+                )
+            })?
+            .clone();
         let downloader = Arc::clone(&self.http_downloader);
         let progress_tracker = Arc::clone(&self.progress_tracker);
         let integrity_checker = Arc::clone(&self.integrity_checker);


### PR DESCRIPTION
## Summary
- Removes a latent panic in \`DownloadManager::start_download\`: \`self.event_sender.as_ref().unwrap()\` is replaced by an \`ok_or_else\` returning \`AppError::Download\` so the caller gets a recoverable error if \`set_event_sender\` was not invoked first.
- Sibling code at \`manager.rs:1083\` already treats this field as optional, so the \`unwrap\` was the inconsistent path.

Refs: \`docs/reviews/CODE_REVIEW.md\` R-01 (PR #14)

## Test plan
- [ ] \`cargo test --manifest-path src-tauri/Cargo.toml\`
- [ ] \`cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings\`
- [ ] Smoke: launch app, start a download — flow unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)