### PR TITLE
chore(husky): migrate to v9 prepare command

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 LOG_DIR="$ROOT_DIR/.planning/logs"
 mkdir -p "$LOG_DIR"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 ROOT_DIR="$(git rev-parse --show-toplevel)"
 LOG_DIR="$ROOT_DIR/.planning/logs"
 mkdir -p "$LOG_DIR"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "format": "prettier --write .",
     "type-check": "tsc --noEmit",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.0",


### PR DESCRIPTION
## Summary
- husky v9 deprecates \`husky install\`; v10 will fail with the legacy preamble. Switch to v9 syntax now to avoid breakage on the next major.
- \`pnpm install\` now runs \`prepare\` cleanly with no deprecation warning.

## Changes
- \`package.json\`: \`"prepare": "husky install"\` → \`"prepare": "husky"\`.
- \`.husky/post-commit\` and \`.husky/post-merge\`: remove the legacy shebang + \`. husky.sh\` source line (v9 sources hooks itself).

## Test plan
- [x] \`pnpm install --frozen-lockfile\` (no DEPRECATED warning)
- [ ] Make a local commit and confirm \`post-commit\` still triggers the hermes log writer

Refs PR #14, \`CODE_REVIEW.md\` F-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)