### PR TITLE
chore(scripts): make test:all portable across machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:integration": "vitest --config vitest.config.integration.ts",
     "test:integration:ui": "vitest --config vitest.config.integration.ts --ui",
     "test:e2e": "vitest run --config vitest.config.integration.ts",
-    "test:all": "~/.hermes/node/bin/corepack pnpm lint && ~/.hermes/node/bin/corepack pnpm type-check && ~/.hermes/node/bin/corepack pnpm exec vitest run && ~/.hermes/node/bin/corepack pnpm exec vitest run --config vitest.config.integration.ts && ~/.cargo/bin/cargo fmt --manifest-path src-tauri/Cargo.toml --all --check && ~/.cargo/bin/cargo test --manifest-path src-tauri/Cargo.toml && ~/.cargo/bin/cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings",
+    "test:all": "pnpm lint && pnpm type-check && pnpm exec vitest run && pnpm exec vitest run --config vitest.config.integration.ts && cargo fmt --manifest-path src-tauri/Cargo.toml --all --check && cargo test --manifest-path src-tauri/Cargo.toml && cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext ts,tsx --fix",
     "format": "prettier --write .",


### PR DESCRIPTION
## Summary
Removes \`~/.hermes/node/bin/corepack\` and \`~/.cargo/bin/cargo\` absolute paths from \`scripts.test:all\`. Script now uses bare \`pnpm\` and \`cargo\` from \`PATH\` so it runs on CI, fresh clones, and contributors who installed the toolchain via Homebrew / rustup / nvm.

## Test plan
- [ ] On a machine with \`pnpm\` and \`cargo\` on PATH: \`pnpm test:all\` runs all seven steps
- [ ] CI: same green run

Refs PR #14, \`CODE_REVIEW.md\` B-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)