### PR TITLE
security(csp): drop unsafe-eval and dedupe connect-src

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -60,7 +60,7 @@
       "menuOnLeftClick": false
     },
     "security": {
-      "csp": "default-src 'self'; img-src 'self' asset: https://asset.localhost data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' asset: https://asset.localhost; script-src 'self' 'unsafe-eval'; connect-src ipc: http://ipc.localhost 'self' ipc: http://ipc.localhost; media-src 'self' asset: https://asset.localhost"
+      "csp": "default-src 'self'; img-src 'self' asset: https://asset.localhost data: blob:; style-src 'self' 'unsafe-inline'; font-src 'self' asset: https://asset.localhost; script-src 'self'; connect-src 'self' ipc: http://ipc.localhost; media-src 'self' asset: https://asset.localhost"
     },
     "windows": [
       {


### PR DESCRIPTION
## Summary
- Tightens \`tauri.conf.json#app.security.csp\` by removing \`'unsafe-eval'\` from \`script-src\` and collapsing the duplicated \`ipc: http://ipc.localhost\` pair in \`connect-src\`.
- No production code path uses \`eval()\` / \`new Function()\` — Vite + React 19 bundles compile to static modules, so removing the directive is purely tightening attack surface.

## Risk
- 🟡 If Vite HMR in \`tauri dev\` ever needs eval (rare, version-dependent), put \`'unsafe-eval'\` only in \`tauri.conf.local.json\` rather than weakening the prod CSP.
- **Reviewer should run** \`pnpm tauri dev\` and \`pnpm tauri build\` on at least one OS to confirm no CSP violations are logged in the webview console.

## Test plan
- [ ] \`pnpm tauri dev\` — open dev tools, confirm 0 CSP errors during HMR
- [ ] \`pnpm tauri build\` — install and launch the prod bundle, exercise downloads, confirm 0 CSP errors

Refs PR #14, \`SECURITY_REVIEW.md\` S-01 / S-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)