### PR TITLE
security(commands): hard-gate yt-dlp/youtube-dl URLs to http(s)

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -198,6 +198,8 @@ fn is_youtube_url(url: &str) -> bool {
 }
 
 async fn get_video_info_with_ytdlp(url: &str) -> AppResult<serde_json::Value> {
+    crate::utils::validation::assert_http_url(url)?;
+
     let output = tokio::process::Command::new("yt-dlp")
         .args(["--dump-json", "--no-download", url])
         .output()
@@ -217,6 +219,8 @@ async fn get_video_info_with_ytdlp(url: &str) -> AppResult<serde_json::Value> {
 }
 
 async fn get_video_info_with_youtubedl(url: &str) -> AppResult<serde_json::Value> {
+    crate::utils::validation::assert_http_url(url)?;
+
     let output = tokio::process::Command::new("youtube-dl")
         .args(["--dump-json", "--no-download", url])
         .output()

--- a/src-tauri/src/commands/youtube.rs
+++ b/src-tauri/src/commands/youtube.rs
@@ -34,6 +34,9 @@ pub(crate) async fn get_youtube_info_internal(url: &str) -> AppResult<YoutubeVid
 // Helper functions using yt-dlp
 
 async fn get_video_info_with_ytdlp(url: &str) -> AppResult<YoutubeVideoInfo> {
+    crate::utils::validation::assert_http_url(url)
+        .map_err(|e| AppError::Youtube(e.to_string()))?;
+
     let output = tokio::process::Command::new("yt-dlp")
         .args(["--dump-json", "--no-warnings", "--no-playlist", url])
         .output()

--- a/src-tauri/src/utils/validation.rs
+++ b/src-tauri/src/utils/validation.rs
@@ -3,6 +3,8 @@
 use anyhow::{anyhow, Result};
 use url::Url;
 
+use crate::core::models::{AppError, AppResult};
+
 /// Validate if URL is accessible
 pub fn validate_url(url: &str) -> Result<Url> {
     Url::parse(url).map_err(|e| anyhow!("Invalid URL format: {}", e))
@@ -15,5 +17,54 @@ pub fn is_valid_video_url(url: &str) -> bool {
         scheme == "http" || scheme == "https"
     } else {
         false
+    }
+}
+
+/// Assert that the input parses as a URL with an http(s) scheme.
+///
+/// Used as a hard gate before passing a URL to external subprocesses
+/// (yt-dlp, youtube-dl, ffmpeg). Rejects `file://`, `javascript:`,
+/// `ftp://`, and any other scheme even if upstream validators were
+/// bypassed or removed.
+pub fn assert_http_url(url: &str) -> AppResult<()> {
+    let parsed = Url::parse(url)
+        .map_err(|e| AppError::System(format!("invalid URL: {}", e)))?;
+    match parsed.scheme() {
+        "http" | "https" => Ok(()),
+        other => Err(AppError::System(format!(
+            "unsupported URL scheme `{}` — only http/https are allowed",
+            other
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn assert_http_url_accepts_http_and_https() {
+        assert!(assert_http_url("http://example.com/video.mp4").is_ok());
+        assert!(assert_http_url("https://youtu.be/dQw4w9WgXcQ").is_ok());
+    }
+
+    #[test]
+    fn assert_http_url_rejects_dangerous_schemes() {
+        for bad in [
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "data:text/html,<script>1</script>",
+            "ftp://example.com/x",
+            "ssh://attacker/x",
+        ] {
+            let err = assert_http_url(bad).expect_err(bad);
+            assert!(matches!(err, AppError::System(_)), "{}", bad);
+        }
+    }
+
+    #[test]
+    fn assert_http_url_rejects_unparseable_input() {
+        assert!(assert_http_url("not a url").is_err());
+        assert!(assert_http_url("").is_err());
     }
 }


### PR DESCRIPTION
## Summary
Defense-in-depth scheme whitelist for every \`yt-dlp\` / \`youtube-dl\` subprocess invocation. Even if the existing upstream validators (\`validate_url_impl\`, \`is_valid_youtube_url\`) are removed or bypassed, the external binary now never receives \`file://\`, \`javascript:\`, \`data:\`, \`ftp://\`, or any other non-http(s) scheme.

## Changes
- New helper \`utils::validation::assert_http_url(&str) -> AppResult<()>\` — parses with \`url::Url\` and rejects everything but \`http\` / \`https\`.
- Calls it at the top of:
  - \`commands/system.rs::get_video_info_with_ytdlp\`
  - \`commands/system.rs::get_video_info_with_youtubedl\`
  - \`commands/youtube.rs::get_video_info_with_ytdlp\`
- Unit tests cover acceptance, five dangerous-scheme rejections, and unparseable input.

## Risk
- 🟢 Low. The accepted set (\`http\`/\`https\`) is what yt-dlp practically supports for video downloads. Tests + smoke run of \`get_video_info\` should be enough.

## Test plan
- [ ] \`cargo test --manifest-path src-tauri/Cargo.toml utils::validation\`
- [ ] \`cargo test --manifest-path src-tauri/Cargo.toml\` (full suite, no regressions)
- [ ] Manual: invoke \`get_video_info\` with a real YouTube URL — still succeeds

Refs PR #14, \`SECURITY_REVIEW.md\` S-04, \`CODE_REVIEW.md\` R-05.

🤖 Generated with [Claude Code](https://claude.com/claude-code)