### PR TITLE
chore(clippy): document unwrap_used rollout plan at crate root

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,14 @@
 //! This library provides the core functionality for the video downloader application,
 //! including download management, file parsing, and system utilities.
 
+// TODO(R-03 / docs/reviews/CODE_REVIEW.md): roll out crate-wide
+// #![warn(clippy::unwrap_used, clippy::expect_used)] once each pre-existing
+// call site has been audited (~150 unwraps across core/*). Doing it crate-wide
+// today would be denied by `cargo clippy -- -D warnings` in CI. Until that
+// audit lands, *new* modules in safety-critical paths should opt in locally
+// via `#![deny(clippy::unwrap_used, clippy::expect_used)]` at the top of the
+// file, and tests within those modules should `#[allow(...)]` the same lint.
+
 pub mod commands;
 pub mod core;
 pub mod engine;


### PR DESCRIPTION
## Summary
Adds a top-of-file TODO in \`src-tauri/src/lib.rs\` that captures why \`#![warn(clippy::unwrap_used, clippy::expect_used)]\` can't be flipped on globally today (CI's \`-D warnings\` would deny ~150 pre-existing call sites) and what the interim policy is for new modules.

This is the smallest landable shape of PR-C. The actual lint flip will be a series of per-module cleanup PRs, one file at a time.

## Changes
- \`src-tauri/src/lib.rs\`: 8-line TODO comment block. No code, no behaviour change.

## Test plan
- [x] \`cargo build\` not affected (comment-only)
- [ ] Reviewer agrees on the per-file deny policy for new safety-critical modules

Refs PR #14, \`CODE_REVIEW.md\` R-03.

🤖 Generated with [Claude Code](https://claude.com/claude-code)